### PR TITLE
Change license from MIT to Apache 2.0

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,16 @@
+Copyright 2024 Andrea Raponi
+
+This product includes software developed by the Dito project:
+https://github.com/andrearaponi/dito
+
+This product also includes third-party software distributed under their respective licenses:
+
+- github.com/beorn7/perks/quantile: MIT License
+- github.com/cespare/xxhash/v2: MIT License
+- github.com/dgryski/go-rendezvous: MIT License
+- github.com/gorilla/websocket: BSD-2-Clause License
+- github.com/klauspost/compress: Apache License 2.0
+- github.com/redis/go-redis/v9: BSD-2-Clause License
+- golang.org/x/sys/unix: BSD-3-Clause License
+- gopkg.in/yaml.v3: MIT License
+- google.golang.org/protobuf: BSD-3-Clause License

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <div align="center">
     <h1>Dito</h1>
     <img src="https://img.shields.io/badge/status-active-green.svg">
-    <img src="https://img.shields.io/badge/release-0.5.1-green.svg">
+    <img src="https://img.shields.io/badge/release-0.6.0-green.svg">
     <img src="https://img.shields.io/badge/license-MIT-blue.svg">
     <img src="https://img.shields.io/badge/language-Go-blue.svg">
     <img src="dito.png" alt="Dito Logo" >
@@ -295,4 +295,5 @@ If you encounter any issues while using Dito, please follow these steps to open 
 
 ## License
 
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the Apache License 2.0. See the [LICENSE](./LICENSE) file for details.
+


### PR DESCRIPTION
License updated from MIT to Apache 2.0 to align with CNCF standards and provide better patent protection.
